### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 A Model Context Protocol (MCP) server that provides a natural language interface for managing Keycloak identity and access management through its REST API. This server enables AI agents to perform user management, client configuration, realm administration, and role-based access control operations seamlessly.
 
+<a href="https://glama.ai/mcp/servers/@idoyudha/mcp-keycloak">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@idoyudha/mcp-keycloak/badge" alt="mcp-keycloak MCP server" />
+</a>
+
 ## Overview
 
 The Keycloak MCP Server bridges the gap between AI applications and Keycloak's powerful identity management capabilities. Whether you're building an AI assistant that needs to manage users, configure clients, or handle complex authorization scenarios, this server provides the tools you need through simple, natural language commands.


### PR DESCRIPTION
This PR adds a badge for the [mcp-keycloak](https://glama.ai/mcp/servers/@idoyudha/mcp-keycloak) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@idoyudha/mcp-keycloak">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@idoyudha/mcp-keycloak/badge" alt="mcp-keycloak MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.